### PR TITLE
Add empty body with tool id in PSM ADF

### DIFF
--- a/ADF/ghosts_actuators_psm1.yaml
+++ b/ADF/ghosts_actuators_psm1.yaml
@@ -93,6 +93,6 @@ ACTUATOR Actuator0:
   location:
     orientation: {p: 0.0, r: 0.0, y: 0.0}
     position: {x: 0.0, y: -0.010, z: 0.0}
-  parent: /ambf/env/420006/psm1/BODY tool yaw link
+  parent: /ambf/env/psm1/BODY tool yaw link
   visible: False
   visible size: 0.0005

--- a/ADF/ghosts_actuators_psm2.yaml
+++ b/ADF/ghosts_actuators_psm2.yaml
@@ -93,6 +93,6 @@ ACTUATOR Actuator0:
   location:
     orientation: {p: 0.0, r: 0.0, y: 0.0}
     position: {x: 0.0, y: -0.010, z: 0.0}
-  parent: /ambf/env/420006/psm2/BODY tool yaw link
+  parent: /ambf/env/psm2/BODY tool yaw link
   visible: False
   visible size: 0.0005

--- a/ADF/psm1_LND_420006.yaml
+++ b/ADF/psm1_LND_420006.yaml
@@ -12,6 +12,7 @@ bodies:
 - BODY tool roll link
 - BODY tool yaw link
 - BODY yaw link
+- BODY tool id
 joints:
 - JOINT base link-yaw link
 - JOINT yaw link-pitch end link
@@ -34,7 +35,15 @@ gravity:
   x: 0.0
   y: 0.0
   z: 0.0
-namespace: /ambf/env/420006/psm1/
+namespace: /ambf/env/psm1/
+
+BODY tool id:
+  name: tool_id/420006
+  mesh: ''
+  collision mesh: ''
+  collision mesh type: ''
+  passive: false
+  mass: 0.0
 
 BODY base link:
   name: base link

--- a/ADF/psm2_LND_420006.yaml
+++ b/ADF/psm2_LND_420006.yaml
@@ -12,6 +12,7 @@ bodies:
 - BODY tool roll link
 - BODY tool yaw link
 - BODY yaw link
+- BODY tool id
 joints:
 - JOINT base link-yaw link
 - JOINT yaw link-pitch end link
@@ -34,7 +35,14 @@ gravity:
   x: 0.0
   y: 0.0
   z: 0.0
-namespace: /ambf/env/420006/psm2/
+namespace: /ambf/env/psm2/
+
+BODY tool id:
+  name: tool_id/420006
+  mesh: ''
+  collision mesh: ''
+  collision mesh type: ''
+  passive: false
 
 BODY base link:
   name: base link

--- a/ADF/sensors_actuators_psm1_LND_420006.yaml
+++ b/ADF/sensors_actuators_psm1_LND_420006.yaml
@@ -19,7 +19,7 @@ SENSOR Sensor0:
       offset: {x: 0.0, y: 0.0, z: 0.0}
       direction: {x: 0.0, y: -1.0, z: 0.0}
   range: 0.007
-  parent: /ambf/env/420006/psm1/BODY tool yaw link
+  parent: /ambf/env/psm1/BODY tool yaw link
   visible: False
   visible size: 0.0005
 
@@ -29,6 +29,6 @@ ACTUATOR Actuator0:
   location:
     orientation: {p: 0.0, r: 0.0, y: 0.0}
     position: {x: 0.0, y: -0.010, z: 0.0}
-  parent: /ambf/env/420006/psm1/BODY tool yaw link
+  parent: /ambf/env/psm1/BODY tool yaw link
   visible: False
   visible size: 0.0005

--- a/ADF/sensors_actuators_psm2_LND_420006.yaml
+++ b/ADF/sensors_actuators_psm2_LND_420006.yaml
@@ -12,14 +12,13 @@ SENSOR Sensor0:
   name: Sensor0
   type: Proximity
   location:
-    orientation: {p: 0.0, r: 0.0, y: 0.0}
-    position: {x: 0.0, y: -0.003, z: 0.0}
+    orientation: { p: 0.0, r: 0.0, y: 0.0 }
+    position: { x: 0.0, y: -0.003, z: 0.0 }
   array:
-    -
-      offset: {x: 0.0, y: 0.0, z: 0.0}
-      direction: {x: 0.0, y: -1.0, z: 0.0}
+    - offset: { x: 0.0, y: 0.0, z: 0.0 }
+      direction: { x: 0.0, y: -1.0, z: 0.0 }
   range: 0.007
-  parent: /ambf/env/420006/psm2/BODY tool yaw link
+  parent: /ambf/env/psm2/BODY tool yaw link
   visible: False
   visible size: 0.0005
 
@@ -27,8 +26,8 @@ ACTUATOR Actuator0:
   name: Actuator0
   type: Constraint
   location:
-    orientation: {p: 0.0, r: 0.0, y: 0.0}
-    position: {x: 0.0, y: -0.010, z: 0.0}
-  parent: /ambf/env/420006/psm2/BODY tool yaw link
+    orientation: { p: 0.0, r: 0.0, y: 0.0 }
+    position: { x: 0.0, y: -0.010, z: 0.0 }
+  parent: /ambf/env/psm2/BODY tool yaw link
   visible: False
   visible size: 0.0005

--- a/scripts/surgical_robotics_challenge/simulation_manager.py
+++ b/scripts/surgical_robotics_challenge/simulation_manager.py
@@ -63,8 +63,12 @@ class SimulationManager:
         self._client = Client(name)
         self._client.connect()
 
-    def get_obj_handle(self, name)->SimulationObject:
+    def get_obj_handle(self, name, required: bool= False)->SimulationObject:
         ambf_object = self._client.get_obj_handle(name)
+        
+        if required and ambf_object is None:
+            raise RuntimeError(f"SimulationObject {name} is required not found in the simulation")
+
         if ambf_object:
             return SimulationObject(ambf_object)
         else:

--- a/scripts/tests/test_create_psm_without_tool_id.py
+++ b/scripts/tests/test_create_psm_without_tool_id.py
@@ -1,0 +1,13 @@
+
+from surgical_robotics_challenge.simulation_manager import SimulationManager
+from surgical_robotics_challenge.psm_arm import PSM
+
+sim = SimulationManager('sim_man')
+
+tool_id_body = sim.get_obj_handle('psm1/tool_id')
+psm1 = PSM(sim, 'psm1')
+psm2 = PSM(sim, 'psm2')
+
+print(tool_id_body.get_ros_name())
+print(psm1.tool_id)
+print(psm2.tool_id)


### PR DESCRIPTION
- Automatic tool detection is done by querying the name of the empty body.
- Empty body will specify the tool_id in its name. For example:

```
BODY tool id:
  name: tool_id/420006
```